### PR TITLE
Improve performance of the "status" operation

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -890,7 +890,13 @@ static bool RunStatus(const TArray<FString>& InFiles, const EConcurrency::Type I
 			// The above cannot detect assets removed / locally deleted since there is no file left to enumerate (either by the Content Browser or by File Manager)
 			// => so we also parse the status results to explicitly look for Removed/Deleted assets
 			if (Results.Num() > 0)
-				Results.RemoveAt(0, 1);// Before that, remove the first line, Changeset
+			{
+				Results.RemoveAt(0, 1);// Before that, remove the first line (Workspace/Changeset info)
+			}
+			else
+			{
+				UE_LOG(LogSourceControl, Error, TEXT("RunStatus(%s): the status of the '%s' directory didn't return any header to remove"), *InFiles[0], *Path);
+			}
 			ParseDirectoryStatusResult(Results, OutStates);
 		}
 		else

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -493,7 +493,7 @@ static bool ParseWorkspaceInformation(const TArray<FString>& InInfoMessages, int
 {
 	bool bResult = true;
 
-	// Get workspace config, in the form "cs:41@rep:UE4PlasticPlugin@repserver:localhost:8087" (from the "--wkconfig" flag)
+	// Get workspace status, in the form "cs:41@rep:UE4PlasticPlugin@repserver:localhost:8087" (disabled by the "--nostatus" flag)
 	//                                or "cs:41@rep:UE4PlasticPlugin@repserver:SRombauts@cloud" (when connected directly to the cloud)
 	if (InInfoMessages.Num() > 0)
 	{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -889,7 +889,8 @@ static bool RunStatus(const TArray<FString>& InFiles, const EConcurrency::Type I
 			ParseFileStatusResult(FileVisitor.Files, Results, OutStates, OutChangeset, OutBranchName);
 			// The above cannot detect assets removed / locally deleted since there is no file left to enumerate (either by the Content Browser or by File Manager)
 			// => so we also parse the status results to explicitly look for Removed/Deleted assets
-			Results.RemoveAt(0, 2); // Before that, remove the first two line Changeset, and BranchName
+			if (Results.Num() > 0)
+				Results.RemoveAt(0, 1);// Before that, remove the first line, Changeset
 			ParseDirectoryStatusResult(Results, OutStates);
 		}
 		else


### PR DESCRIPTION
Don't use --wkconfig on all status commands since it's generating two network calls to the server (GetBranchInfoByName & GetLastChangesetOnBranch)