### PR TITLE
Fix optimization in RunFileinfo() causing wrong file status…

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -945,6 +945,8 @@ static void ParseFileinfoResults(const TArray<FString>& InResults, TArray<FPlast
 	const FPlasticSourceControlModule& PlasticSourceControl = FModuleManager::GetModuleChecked<FPlasticSourceControlModule>("PlasticSourceControl");
 	const FPlasticSourceControlProvider& Provider = PlasticSourceControl.GetProvider();
 
+	ensureMsgf(InResults.Num() == InOutStates.Num(), TEXT("The fileinfo command should gives the same number of infos as the status command"));
+
 	// Iterate on all files and all status of the result (assuming same number of line of results than number of file states)
 	for (int32 IdxResult = 0; IdxResult < InResults.Num(); IdxResult++)
 	{


### PR DESCRIPTION
… on folders with newly added files (or moved files etc) that is, heterogenous content other than Controlled, Changed, Replaced, Conflicted

The optimization can only be used if all files are optimized out (avoiding the "fileinfo" command entirely)
else we have to keep them all since ParseFileinfoResults() expect the same number of lines of results as there are files listed in the query

So it is a "all or nothing" optimization