### PR TITLE
Fix deprecation warning in XmlParser

### DIFF
--- a/Source/XmlParser2/Private/XmlNode.cpp
+++ b/Source/XmlParser2/Private/XmlNode.cpp
@@ -63,7 +63,7 @@ const FXmlNode* FXmlNode::FindChildNode(const FString& InTag) const
 
 FXmlNode* FXmlNode::FindChildNode(const FString& InTag)
 {
-	return const_cast<FXmlNode*>(AsConst(this)->FindChildNode(InTag));
+	return const_cast<FXmlNode*>(AsConst(*this).FindChildNode(InTag));
 }
 
 const FString& FXmlNode::GetTag() const


### PR DESCRIPTION
XmlNode.cpp(66): warning C4996: 'AsConst': Call with a reference instead of a pointer. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.