### PR TITLE
Add a "cm" console command to the Unreal Editor

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlConsole.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlConsole.cpp
@@ -1,0 +1,32 @@
+#include "PlasticSourceControlConsole.h"
+
+#include "HAL/IConsoleManager.h"
+#include "ISourceControlModule.h"
+
+#include "PlasticSourceControlUtils.h"
+
+// Auto-registered console commands:
+// No re-register on hot reload, and unregistered only once on editor shutdown.
+static FAutoConsoleCommand g_executePlasticConsoleCommand(TEXT("cm"),
+	TEXT("PlasticSCM Command Line Interface.\n")
+	TEXT("Run any 'cm' command directly from the Unreal Editor Console.\n")
+	TEXT("Type 'cm showcommands' to get a command list."),
+	FConsoleCommandWithArgsDelegate::CreateStatic(&PlasticSourceControlConsole::ExecutePlasticConsoleCommand));
+
+void PlasticSourceControlConsole::ExecutePlasticConsoleCommand(const TArray<FString>& a_args)
+{
+	// If called with no argument, explicitely call "cm help" instead to mimic the cm CLI behavior.
+	if (a_args.Num() < 1)
+	{
+		ExecutePlasticConsoleCommand(TArray<FString>({TEXT("help")}));
+		return;
+	}
+
+	FString Results;
+	FString Errors;
+	const FString Command = a_args[0];
+	TArray<FString> Parameters = a_args;
+	Parameters.RemoveAt(0);
+	PlasticSourceControlUtils::RunCommandInternal(Command, Parameters, TArray<FString>(), EConcurrency::Synchronous, Results, Errors);
+	UE_LOG(LogSourceControl, Log, TEXT("Output:\n%s"), *Results);
+}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlConsole.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlConsole.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * Editor only console commands.
+ *
+ *  Such commands can be executed from the editor output log window, but also from command line arguments,
+ * from Editor Blueprints utilities, or from C++ Code using. eg. GEngine->Exec("cm status");
+ */
+class PlasticSourceControlConsole
+{
+public:
+	// PlasticSCM Command Line Interface: Run 'cm' commands directly from the Unreal Editor Console.
+	static void ExecutePlasticConsoleCommand(const TArray<FString>& a_args);
+};

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -323,7 +323,7 @@ void Terminate()
 }
 
 // Run command (thread-safe)
-static bool RunCommandInternal(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, FString& OutResults, FString& OutErrors)
+bool RunCommandInternal(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, FString& OutResults, FString& OutErrors)
 {
 	bool bResult = false;
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -96,6 +96,8 @@ bool GetWorkspaceInformation(int32& OutChangeset, FString& OutRepositoryName, FS
  * @returns true if the command succeeded and returned no errors
  */
 bool RunCommand(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, TArray<FString>& OutResults, TArray<FString>& OutErrorMessages);
+// Run a Plastic command - output is a string.
+bool RunCommandInternal(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, FString& OutResults, FString& OutErrors);
 
 /**
  * Run a Plastic "status" command and parse it.


### PR DESCRIPTION
Enable users to call into PlasticSCM Command Line Interface from within the Unreal Editor console,
but also from the Editor command line, or from Blueprint Editor Utilities or from C++ code.