### PR TITLE
Use cm getworkspacefrompath instead of searching for a .plastic directory

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -44,11 +44,11 @@ void FPlasticSourceControlProvider::CheckPlasticAvailability()
 {
 	FPlasticSourceControlModule& PlasticSourceControl = FModuleManager::LoadModuleChecked<FPlasticSourceControlModule>("PlasticSourceControl");
 	FString PathToPlasticBinary = PlasticSourceControl.AccessSettings().GetBinaryPath();
-	if(PathToPlasticBinary.IsEmpty())
+	if (PathToPlasticBinary.IsEmpty())
 	{
 		// Try to find Plastic binary, and update settings accordingly
 		PathToPlasticBinary = PlasticSourceControlUtils::FindPlasticBinaryPath();
-		if(!PathToPlasticBinary.IsEmpty())
+		if (!PathToPlasticBinary.IsEmpty())
 		{
 			PlasticSourceControl.AccessSettings().SetBinaryPath(PathToPlasticBinary);
 		}
@@ -56,20 +56,19 @@ void FPlasticSourceControlProvider::CheckPlasticAvailability()
 
 	if(!PathToPlasticBinary.IsEmpty())
 	{
-		// Find the path to the root Plastic directory (if any, else uses the ProjectDir)
-		const FString PathToProjectDir = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
-		bWorkspaceFound = PlasticSourceControlUtils::FindRootDirectory(PathToProjectDir, PathToWorkspaceRoot);
-
 		// Launch the Plastic SCM cli shell on the background to issue all commands during this session
-		bPlasticAvailable = PlasticSourceControlUtils::LaunchBackgroundPlasticShell(PathToPlasticBinary, PathToWorkspaceRoot);
-		if(bPlasticAvailable)
+		const FString PathToProjectDir = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+		bPlasticAvailable = PlasticSourceControlUtils::LaunchBackgroundPlasticShell(PathToPlasticBinary, PathToProjectDir);
+		if (bPlasticAvailable)
 		{
 			PlasticSourceControlUtils::GetPlasticScmVersion(PlasticScmVersion);
 
 			// Get user name (from the global Plastic SCM client config)
 			PlasticSourceControlUtils::GetUserName(UserName);
 
-			if(!bWorkspaceFound)
+			// Find the path to the root Plastic directory (if any, else uses the ProjectDir)
+			bWorkspaceFound = PlasticSourceControlUtils::GetWorkspacePath(PathToProjectDir, PathToWorkspaceRoot);
+			if (!bWorkspaceFound)
 			{
 				UE_LOG(LogSourceControl, Warning, TEXT("'%s' is not part of a Plastic workspace"), *FPaths::ProjectDir());
 			}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -367,44 +367,17 @@ FString FindPlasticBinaryPath()
 }
 
 // Find the root of the Plastic workspace, looking from the provided path and upward in its parent directories.
-bool FindRootDirectory(const FString& InPath, FString& OutWorkspaceRoot)
+bool GetWorkspacePath(const FString& InPath, FString& OutWorkspaceRoot)
 {
-	bool bFound = false;
-	FString PathToPlasticSubdirectory;
-	OutWorkspaceRoot = InPath;
-
-	auto TrimTrailing = [](FString& Str, const TCHAR Char)
+	TArray<FString> InfoMessages;
+	TArray<FString> ErrorMessages;
+	const TArray<FString> Parameters = { TEXT("--format=\"{wkpath}\""), TEXT(".")};
+	const bool bFound = RunCommand(TEXT("getworkspacefrompath"), Parameters, TArray<FString>(), EConcurrency::Synchronous, InfoMessages, ErrorMessages);
+	if (bFound && InfoMessages.Num() > 0)
 	{
-		int32 Len = Str.Len();
-		while(Len && Str[Len - 1] == Char)
-		{
-			Str = Str.LeftChop(1);
-			Len = Str.Len();
-		}
-	};
-
-	TrimTrailing(OutWorkspaceRoot, '\\');
-	TrimTrailing(OutWorkspaceRoot, '/');
-
-	while(!bFound && !OutWorkspaceRoot.IsEmpty())
-	{
-		// Look for the ".plastic" subdirectory present at the root of every Plastic workspace
-		PathToPlasticSubdirectory = OutWorkspaceRoot / TEXT(".plastic");
-		bFound = IFileManager::Get().DirectoryExists(*PathToPlasticSubdirectory);
-		if(!bFound)
-		{
-			int32 LastSlashIndex;
-			if(OutWorkspaceRoot.FindLastChar(TEXT('/'), LastSlashIndex))
-			{
-				OutWorkspaceRoot = OutWorkspaceRoot.Left(LastSlashIndex);
-			}
-			else
-			{
-				OutWorkspaceRoot.Empty();
-			}
-		}
+		OutWorkspaceRoot = InfoMessages[0];
 	}
-	if (!bFound)
+	else
 	{
 		OutWorkspaceRoot = InPath; // If not found, return the provided dir as best possible root.
 	}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -51,11 +51,11 @@ void Terminate();
 
 /**
  * Find the root of the Plastic workspace, looking from the GameDir and upward in its parent directories
- * @param InPathToGameDir		The path to the Game Directory
- * @param OutWorkspaceRoot		The path to the root directory of the Plastic workspace if found, else the path to the GameDir
+ * @param InPath				The path to start the search from (typically the Game Directory)
+ * @param OutWorkspaceRoot		The path to the root directory of the Plastic workspace if found, else the InPath
  * @returns true if the command succeeded and returned no errors
  */
-bool FindRootDirectory(const FString& InPathToGameDir, FString& OutWorkspaceRoot);
+bool GetWorkspacePath(const FString& InPath, FString& OutWorkspaceRoot);
 
 /**
  * Get Plastic SCM cli version


### PR DESCRIPTION
Replace FindRootDirectory() by GetWorkspacePath() using cm getworkspacefrompath instead of searching for a .plastic folder from the current directory