### PR TITLE
Fix Changeset number not updated anymore by checkin operation

### DIFF
--- a/PlasticSourceControl.uplugin
+++ b/PlasticSourceControl.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 44,
-	"VersionName": "1.4.10",
+	"Version": 45,
+	"VersionName": "1.4.11",
 	"FriendlyName": "Plastic SCM",
 	"Description": "Plastic source control management",
 	"Category": "Source Control",

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The command line needs the quoted path to the UE4Editor.exe, the quoted patch to
 
 This version here is the development version, so it can contain additional fixes, performance improvements or new features.
 
-#### Version 1.4.9 2022/03/12 for UE4.27.2:
+#### Version 1.4.11 2022/03/29 for UE4.27.2:
 - manage connection to the server
 - show current branch name and CL in status text
 - display status icons to show controlled/checked-out/added/deleted/private/changed/ignored/not-up-to-date files

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -343,9 +343,12 @@ void FPlasticSourceControlProvider::UpdateWorkspaceStatus(const class FPlasticSo
 	}
 
 	// And for all operations running UpdateStatus, get Changeset and Branch informations:
-	if (!InCommand.BranchName.IsEmpty())
+	if (InCommand.ChangesetNumber != 0)
 	{
 		ChangesetNumber = InCommand.ChangesetNumber;
+	}
+	if (!InCommand.BranchName.IsEmpty())
+	{
 		BranchName = InCommand.BranchName;
 	}
 }


### PR DESCRIPTION
Displayed on hovering over the tooltip on the source control menu.

This bug was introduced by #5 improve the perf of the status operation (where I removed the --wkconfig call)

The issue is that now the BranchName is often empty while the ChangesetNumber is actually updated, so we need to decouple the update between the two
