### PR TITLE
Fix Changeset number not updated anymore by checkin operation

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -343,9 +343,12 @@ void FPlasticSourceControlProvider::UpdateWorkspaceStatus(const class FPlasticSo
 	}
 
 	// And for all operations running UpdateStatus, get Changeset and Branch informations:
-	if (!InCommand.BranchName.IsEmpty())
+	if (InCommand.ChangesetNumber != 0)
 	{
 		ChangesetNumber = InCommand.ChangesetNumber;
+	}
+	if (!InCommand.BranchName.IsEmpty())
+	{
 		BranchName = InCommand.BranchName;
 	}
 }


### PR DESCRIPTION
Displayed on hovering over the tooltip on the source control menu.

This bug was introduced by https://github.com/PlasticSCM/UE4PlasticPlugin/pull/5 improve the perf of the status operation (where I removed the --wkconfig call)

The issue is that now the BranchName is often empty while the ChangesetNumber is actually updated, so we need to decouple the update between the two