### PR TITLE
Fix source control menu extension to work with UE5

### DIFF
--- a/Source/PlasticSourceControl/PlasticSourceControl.Build.cs
+++ b/Source/PlasticSourceControl/PlasticSourceControl.Build.cs
@@ -25,5 +25,10 @@ public class PlasticSourceControl : ModuleRules
 				"AssetRegistry",
 			}
 		);
+
+		if (Target.Version.MajorVersion == 5)
+		{
+			PrivateDependencyModuleNames.Add("ToolMenus");
+		}
 	}
 }

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
@@ -4,9 +4,11 @@
 
 #include "CoreMinimal.h"
 #include "ISourceControlProvider.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 class FToolBarBuilder;
 class FMenuBuilder;
+struct FToolMenuSection;
 
 /** Plastic SCM extension of the Source Control toolbar menu */
 class FPlasticSourceControlMenu
@@ -29,9 +31,13 @@ private:
 	TArray<UPackage*>	UnlinkPackages(const TArray<FString>& InPackageNames);
 	void				ReloadPackages(TArray<UPackage*>& InPackagesToReload);
 
-	void AddMenuExtension(FMenuBuilder& Builder);
+#if ENGINE_MAJOR_VERSION == 4
+	void AddMenuExtension(FMenuBuilder& Menu);
 
 	TSharedRef<class FExtender> OnExtendLevelEditorViewMenu(const TSharedRef<class FUICommandList> CommandList);
+#elif ENGINE_MAJOR_VERSION == 5
+	void AddMenuExtension(FToolMenuSection& Menu);
+#endif
 
 	void DisplayInProgressNotification(const FText& InOperationInProgressString);
 	void RemoveInProgressNotification();
@@ -39,7 +45,9 @@ private:
 	void DisplayFailureNotification(const FName& InOperationName);
 
 private:
+#if ENGINE_MAJOR_VERSION == 4
 	FDelegateHandle ViewMenuExtenderHandle;
+#endif
 
 	/** Loaded packages to reload after a Sync or Revert operation */
 	TArray<UPackage*> PackagesToReload;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -7,6 +7,7 @@
 #include "IPlasticSourceControlWorker.h"
 #include "PlasticSourceControlState.h"
 #include "PlasticSourceControlMenu.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 DECLARE_DELEGATE_RetVal(FPlasticSourceControlWorkerRef, FGetPlasticSourceControlWorker)
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "ISourceControlRevision.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 class FPlasticSourceControlState;
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "ISourceControlState.h"
 #include "PlasticSourceControlRevision.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 namespace EWorkspaceState
 {

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -19,6 +19,7 @@
 #include "Modules/ModuleManager.h"
 #include "XmlParser.h"
 #include "ISourceControlModule.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 #if PLATFORM_LINUX
 #include <sys/ioctl.h>

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -5,7 +5,11 @@
 #include "PlasticSourceControlModule.h"
 #include "PlasticSourceControlSettings.h"
 #include "PlasticSourceControlState.h"
+#if ENGINE_MAJOR_VERSION == 4
 #include "HAL/PlatformFilemanager.h"
+#elif ENGINE_MAJOR_VERSION == 5
+#include "HAL/PlatformFileManager.h"
+#endif
 #include "HAL/PlatformProcess.h"
 #include "HAL/FileManager.h"
 #include "Misc/ScopeLock.h"


### PR DESCRIPTION
The old FLevelEditorMenuExtender is not used anymore by the Engine, so trying to use it does nothing.

The official multi-user editing plugin "Concert" had to switch to the "ToolMenus" package,
so I borrowed the new method they switched to and adapted the source code.