### PR TITLE
New setting to dynamically enable Source Control's Verbose logs

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -75,7 +75,7 @@ bool FPlasticConnectWorker::Execute(FPlasticSourceControlCommand& InCommand)
 					// Then, update the status of assets in Content/ directory and also Config files,
 					// but only on real (re-)connection (but not each time Login() is called by Rename or Fixup Redirector command to check connection)
 					// and only if enabled in the settings
-					if (!PlasticSourceControl.GetProvider().IsAvailable() && PlasticSourceControl.AccessSettings().UpdateStatusAtStartup())
+					if (!PlasticSourceControl.GetProvider().IsAvailable() && PlasticSourceControl.AccessSettings().GetUpdateStatusAtStartup())
 					{
 						TArray<FString> ProjectDirs;
 						ProjectDirs.Add(FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()));

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -35,6 +35,13 @@ void FPlasticSourceControlProvider::Init(bool bForceConnection)
 		}
 
 		CheckPlasticAvailability();
+
+		// Override the source control logs verbosity level if needed based on settings
+		FPlasticSourceControlModule& PlasticSourceControl = FModuleManager::LoadModuleChecked<FPlasticSourceControlModule>("PlasticSourceControl");
+		if (PlasticSourceControl.AccessSettings().GetEnableVerboseLogs())
+		{
+			PlasticSourceControlUtils::SwitchVerboseLogs(true);
+		}
 	}
 
 	// bForceConnection: not used anymore

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlSettings.cpp
@@ -35,7 +35,7 @@ bool FPlasticSourceControlSettings::SetBinaryPath(const FString& InString)
 	return bChanged;
 }
 
-bool FPlasticSourceControlSettings::UpdateStatusAtStartup() const
+bool FPlasticSourceControlSettings::GetUpdateStatusAtStartup() const
 {
 	FScopeLock ScopeLock(&CriticalSection);
 	return bUpdateStatusAtStartup;
@@ -47,6 +47,18 @@ void FPlasticSourceControlSettings::SetUpdateStatusAtStartup(const bool bInUpdat
 	bUpdateStatusAtStartup = bInUpdateStatusAtStartup;
 }
 
+bool FPlasticSourceControlSettings::GetEnableVerboseLogs() const
+{
+	FScopeLock ScopeLock(&CriticalSection);
+	return bEnableVerboseLogs;
+}
+
+void FPlasticSourceControlSettings::SetEnableVerboseLogs(const bool bInEnableVerboseLogs)
+{
+	FScopeLock ScopeLock(&CriticalSection);
+	bEnableVerboseLogs = bInEnableVerboseLogs;
+}
+
 // This is called at startup nearly before anything else in our module: BinaryPath will then be used by the provider
 void FPlasticSourceControlSettings::LoadSettings()
 {
@@ -54,6 +66,7 @@ void FPlasticSourceControlSettings::LoadSettings()
 	const FString& IniFile = SourceControlHelpers::GetSettingsIni();
 	GConfig->GetString(*PlasticSettingsConstants::SettingsSection, TEXT("BinaryPath"), BinaryPath, IniFile);
 	GConfig->GetBool(*PlasticSettingsConstants::SettingsSection, TEXT("UpdateStatusAtStartup"), bUpdateStatusAtStartup, IniFile);
+	GConfig->GetBool(*PlasticSettingsConstants::SettingsSection, TEXT("EnableVerboseLogs"), bEnableVerboseLogs, IniFile);
 }
 
 void FPlasticSourceControlSettings::SaveSettings() const
@@ -62,4 +75,5 @@ void FPlasticSourceControlSettings::SaveSettings() const
 	const FString& IniFile = SourceControlHelpers::GetSettingsIni();
 	GConfig->SetString(*PlasticSettingsConstants::SettingsSection, TEXT("BinaryPath"), *BinaryPath, IniFile);
 	GConfig->SetBool(*PlasticSettingsConstants::SettingsSection, TEXT("UpdateStatusAtStartup"), bUpdateStatusAtStartup, IniFile);
+	GConfig->SetBool(*PlasticSettingsConstants::SettingsSection, TEXT("EnableVerboseLogs"), bEnableVerboseLogs, IniFile);
 }

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlSettings.h
@@ -12,8 +12,12 @@ public:
 	bool SetBinaryPath(const FString& InString);
 
 	/** Enable an asynchronous "Update Status" at Editor Startup (default is no, can take a long time). */
-	bool UpdateStatusAtStartup() const;
+	bool GetUpdateStatusAtStartup() const;
 	void SetUpdateStatusAtStartup(const bool bInUpdateStatusAtStartup);
+
+	/** Enable LogSourceControl Verbose logs */
+	bool GetEnableVerboseLogs() const;
+	void SetEnableVerboseLogs(const bool bInEnableVerboseLogs);
 
 	/** Load settings from ini file */
 	void LoadSettings();
@@ -28,9 +32,12 @@ private:
 	/** Plastic binary path */
 	FString BinaryPath;
 
-	/** Enable an asynchronous "Update Status" at Editor Startup (default is no).
+	/** Run an asynchronous "Update Status" at Editor Startup (default is no).
 	 * This does not work well with very big projects where this operation could take dozens of seconds
 	 * preventing the project to have any source control support during this time.
 	*/
 	bool bUpdateStatusAtStartup;
+	
+	/** Override LogSourceControl verbosity level to Verbose, and back, if not already VeryVerbose */
+	bool bEnableVerboseLogs;
 };

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1488,4 +1488,16 @@ void RemoveRedundantErrors(FPlasticSourceControlCommand& InCommand, const FStrin
 	}
 }
 
+void SwitchVerboseLogs(const bool bInEnable)
+{
+	if (bInEnable && LogSourceControl.GetVerbosity() < ELogVerbosity::Verbose)
+	{
+		LogSourceControl.SetVerbosity(ELogVerbosity::Verbose);
+	}
+	else if (!bInEnable && LogSourceControl.GetVerbosity() == ELogVerbosity::Verbose)
+	{
+		LogSourceControl.SetVerbosity(ELogVerbosity::Log);
+	}
+}
+
 }

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -144,4 +144,11 @@ bool UpdateCachedStates(TArray<FPlasticSourceControlState>&& InStates);
  */
 void RemoveRedundantErrors(FPlasticSourceControlCommand& InCommand, const FString& InFilter);
 
+/**
+ * Change LogSourceControl verbosity level at startup and when toggled from the Plastic Source Control Settings
+ *
+ * Override to Verbose or back to Log, but only if the current log verbosity is not already set to VeryVerbose
+ */
+void SwitchVerboseLogs(const bool bInEnable);
+
 }

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
@@ -668,6 +668,8 @@ void SPlasticSourceControlSettings::OnCheckedEnableVerboseLogs(ECheckBoxState Ne
 	FPlasticSourceControlModule& PlasticSourceControl = FModuleManager::GetModuleChecked<FPlasticSourceControlModule>("PlasticSourceControl");
 	PlasticSourceControl.AccessSettings().SetEnableVerboseLogs(NewCheckedState == ECheckBoxState::Checked);
 	PlasticSourceControl.AccessSettings().SaveSettings();
+
+	PlasticSourceControlUtils::SwitchVerboseLogs(NewCheckedState == ECheckBoxState::Checked);
 }
 
 ECheckBoxState SPlasticSourceControlSettings::IsEnableVerboseLogsChecked() const

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
@@ -271,7 +271,7 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 					.Font(Font)
 				]
 			]
-			// Option to enable the Update Status operation at Editor Startup
+			// Option to run an Update Status operation at Editor Startup
 			+SVerticalBox::Slot()
 			.AutoHeight()
 			.Padding(2.0f)
@@ -296,6 +296,29 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 				]
 			]
 			// Button to create a new Workspace
+			+SVerticalBox::Slot()
+			.AutoHeight()
+			.Padding(2.0f)
+			.VAlign(VAlign_Center)
+			[
+				SNew(SHorizontalBox)
+				.ToolTipText(LOCTEXT("EnableVerboseLogs_Tooltip", "Override LogSourceControl default verbosity level to Verbose (except if already set to VeryVerbose)."))
+				+SHorizontalBox::Slot()
+				.FillWidth(0.1f)
+				[
+					SNew(SCheckBox)
+					.IsChecked(SPlasticSourceControlSettings::IsEnableVerboseLogsChecked())
+					.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedEnableVerboseLogs)
+				]
+				+SHorizontalBox::Slot()
+				.FillWidth(2.9f)
+				.VAlign(VAlign_Center)
+				[
+					SNew(STextBlock)
+					.Text(LOCTEXT("EnableVerboseLogs", "Enable Source Control Verbose logs"))
+					.Font(Font)
+				]
+			]
 			+SVerticalBox::Slot()
 			.FillHeight(2.5f)
 			.Padding(4.0f)
@@ -634,15 +657,23 @@ void SPlasticSourceControlSettings::OnCheckedUpdateStatusAtStartup(ECheckBoxStat
 	PlasticSourceControl.AccessSettings().SaveSettings();
 }
 
-bool SPlasticSourceControlSettings::UpdateStatusAtStartup() const
-{
-	const FPlasticSourceControlModule& PlasticSourceControl = FModuleManager::GetModuleChecked<FPlasticSourceControlModule>("PlasticSourceControl");
-	return PlasticSourceControl.AccessSettings().UpdateStatusAtStartup();
-}
-
 ECheckBoxState SPlasticSourceControlSettings::IsUpdateStatusAtStartupChecked() const
 {
-	return (UpdateStatusAtStartup() ? ECheckBoxState::Checked : ECheckBoxState::Unchecked);
+	const FPlasticSourceControlModule& PlasticSourceControl = FModuleManager::GetModuleChecked<FPlasticSourceControlModule>("PlasticSourceControl");
+	return PlasticSourceControl.AccessSettings().GetUpdateStatusAtStartup() ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+}
+
+void SPlasticSourceControlSettings::OnCheckedEnableVerboseLogs(ECheckBoxState NewCheckedState)
+{
+	FPlasticSourceControlModule& PlasticSourceControl = FModuleManager::GetModuleChecked<FPlasticSourceControlModule>("PlasticSourceControl");
+	PlasticSourceControl.AccessSettings().SetEnableVerboseLogs(NewCheckedState == ECheckBoxState::Checked);
+	PlasticSourceControl.AccessSettings().SaveSettings();
+}
+
+ECheckBoxState SPlasticSourceControlSettings::IsEnableVerboseLogsChecked() const
+{
+	const FPlasticSourceControlModule& PlasticSourceControl = FModuleManager::GetModuleChecked<FPlasticSourceControlModule>("PlasticSourceControl");
+	return PlasticSourceControl.AccessSettings().GetEnableVerboseLogs() ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
 }
 
 /** Path to the "ignore.conf" file */

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
@@ -53,7 +53,9 @@ private:
 
 	void OnCheckedUpdateStatusAtStartup(ECheckBoxState NewCheckedState);
 	ECheckBoxState IsUpdateStatusAtStartupChecked() const;
-	bool UpdateStatusAtStartup() const;
+
+	void OnCheckedEnableVerboseLogs(ECheckBoxState NewCheckedState);
+	ECheckBoxState IsEnableVerboseLogsChecked() const;
 
 	void OnCheckedInitialCommit(ECheckBoxState NewCheckedState);
 	bool bAutoInitialCommit;


### PR DESCRIPTION
Add a setting with a check box to dynamically override LogSourceControl to Verbose and back to default Log level
provided that the logs are not already set to VeryVerbose by configuration in [Core.Log]