### PR TITLE
Fix restart shell after timeout

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -266,11 +266,10 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 		}
 		else if (FPlatformTime::Seconds() - LastActivity > Timeout)
 		{
-			// In case of timeout, ask the blocking 'cm shell' process to exit, and detach from it immediatly: it will be relaunched by next command
-			UE_LOG(LogSourceControl, Error, TEXT("RunCommand: '%s' %d TIMEOUT after %.3lfs output (%d chars):\n%s"), *InCommand, bResult, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len(), *OutResults.Mid(PreviousLogLen));
-			FPlatformProcess::WritePipe(ShellInputPipeWrite, TEXT("exit"));
-			FPlatformProcess::CloseProc(ShellProcessHandle);
-			_CleanupBackgroundCommandLineShell();
+			// In case of timeout, ask the blocking 'cm shell' process to exit, detach from it and restart it immediatly
+			UE_LOG(LogSourceControl, Error, TEXT("RunCommand: '%s' TIMEOUT after %.3lfs output (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len(), *OutResults.Mid(PreviousLogLen));
+			_RestartBackgroundCommandLineShell();
+			return false;
 		}
 
 		FPlatformProcess::Sleep(0.001f);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -343,22 +343,10 @@ void Terminate()
 // Run command (thread-safe)
 bool RunCommandInternal(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, FString& OutResults, FString& OutErrors)
 {
-	bool bResult = false;
-
 	// Protect public APIs from multi-thread access
 	FScopeLock Lock(&ShellCriticalSection);
 
-	if (ShellProcessHandle.IsValid())
-	{
-		bResult = _RunCommandInternal(InCommand, InParameters, InFiles, InConcurrency, OutResults, OutErrors);
-	}
-	else
-	{
-		UE_LOG(LogSourceControl, Error, TEXT("RunCommand: '%s': cm shell not running (count %d)"), *InCommand, ShellCommandCounter);
-		OutErrors = InCommand + ": Plastic SCM shell not running!";
-	}
-
-	return bResult;
+	return _RunCommandInternal(InCommand, InParameters, InFiles, InConcurrency, OutResults, OutErrors);
 }
 
 // Basic parsing or results & errors from the Plastic command line process


### PR DESCRIPTION
Improve internal _ExitBackgroundCommandLineShell(), use it for _RestartBackgroundCommandLineShell(), and use this one in case of Timeout

- Check the ShellProcessHandle inside the function instead of outside
- Check if IsProcessRunning() before calling "exit"
- Don't use _RunCommandInternal() anymore so we don't risk recursive calls, directly write to the pipe
- Warn if the shell didn't exit in time, before killing it

Also add #ifdef UE4 around CreatePipeWrite() now that UE5 support it correctly