### PR TITLE
Fix Locked & Not-at-head status erased on "Submit content"

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -173,7 +173,7 @@ bool FPlasticCheckInWorker::Execute(FPlasticSourceControlCommand& InCommand)
 
 	// make a temp file to place our commit message in
 	FScopedTempFile CommitMsgFile(Operation->GetDescription());
-	if (CommitMsgFile.GetFilename().Len() > 0)
+	if (!CommitMsgFile.GetFilename().IsEmpty())
 	{
 		TArray<FString> Parameters;
 		FString ParamCommitMsgFilename = TEXT("--commentsfile=\"");

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -114,7 +114,7 @@ TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> FPlasticSourceContro
 	else
 	{
 		// cache an unknown state for this item
-		TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> NewState = MakeShareable(new FPlasticSourceControlState(InFilename));
+		TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> NewState = MakeShareable(new FPlasticSourceControlState(FString(InFilename)));
 		StateCache.Add(InFilename, NewState);
 		return NewState;
 	}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -328,7 +328,7 @@ void FPlasticSourceControlProvider::UpdateWorkspaceStatus(const class FPlasticSo
 	{
 		// Is connection successful?
 		bServerAvailable = InCommand.bCommandSuccessful;
-		bWorkspaceFound = (InCommand.WorkspaceName.Len() > 0);
+		bWorkspaceFound = !InCommand.WorkspaceName.IsEmpty();
 
 		WorkspaceName = InCommand.WorkspaceName;
 		RepositoryName = InCommand.RepositoryName;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -289,14 +289,16 @@ const FDateTime& FPlasticSourceControlState::GetTimeStamp() const
 // Deleted and Missing assets cannot appear in the Content Browser but does appear in Submit to Source Control Window
 bool FPlasticSourceControlState::CanCheckIn() const
 {
-	const bool bCanCheckIn = WorkspaceState == EWorkspaceState::Added
+	const bool bCanCheckIn =
+		(  WorkspaceState == EWorkspaceState::Added
 		|| WorkspaceState == EWorkspaceState::Deleted
 		|| WorkspaceState == EWorkspaceState::LocallyDeleted
 		|| WorkspaceState == EWorkspaceState::Changed
 		|| WorkspaceState == EWorkspaceState::Moved
 		|| WorkspaceState == EWorkspaceState::Copied
 		|| WorkspaceState == EWorkspaceState::Replaced
-		|| WorkspaceState == EWorkspaceState::CheckedOut;
+		|| WorkspaceState == EWorkspaceState::CheckedOut
+		) && !IsConflicted() && IsCurrent();
 
 	if (!IsUnknown()) UE_LOG(LogSourceControl, Verbose, TEXT("%s CanCheckIn=%d"), *LocalFilename, bCanCheckIn);
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -38,16 +38,21 @@ public:
 	FPlasticSourceControlState(FString&& InLocalFilename)
 		: LocalFilename(MoveTemp(InLocalFilename))
 		, WorkspaceState(EWorkspaceState::Unknown)
-		, DepotRevisionChangeset(-1)
-		, LocalRevisionChangeset(-1)
+		, DepotRevisionChangeset(INVALID_REVISION)
+		, LocalRevisionChangeset(INVALID_REVISION)
 		, TimeStamp(0)
 	{
 	}
 
+	FPlasticSourceControlState() = delete;
 	FPlasticSourceControlState(const FPlasticSourceControlState& InState) = delete;
 	const FPlasticSourceControlState& operator=(const FPlasticSourceControlState& InState) = delete;
 
 	FPlasticSourceControlState(FPlasticSourceControlState&& InState)
+		: WorkspaceState(EWorkspaceState::Unknown)
+		, DepotRevisionChangeset(INVALID_REVISION)
+		, LocalRevisionChangeset(INVALID_REVISION)
+		, TimeStamp(0)
 	{
 		Move(MoveTemp(InState));
 	}
@@ -62,16 +67,26 @@ public:
 	{
 		History = MoveTemp(InState.History);
 		LocalFilename = MoveTemp(InState.LocalFilename);
-		RepSpec = MoveTemp(InState.RepSpec);
+		WorkspaceState = InState.WorkspaceState;
 		PendingMergeFilename = MoveTemp(InState.PendingMergeFilename);
 		PendingMergeBaseChangeset = InState.PendingMergeBaseChangeset;
 		PendingMergeSourceChangeset = InState.PendingMergeSourceChangeset;
 		PendingMergeParameters = MoveTemp(InState.PendingMergeParameters);
-		LockedBy = MoveTemp(InState.LockedBy);
-		LockedWhere = MoveTemp(InState.LockedWhere);
-		WorkspaceState = InState.WorkspaceState;
-		DepotRevisionChangeset = InState.DepotRevisionChangeset;
-		LocalRevisionChangeset = InState.LocalRevisionChangeset;
+		// Update "fileinfo" information only if the command was issued
+		if (InState.DepotRevisionChangeset != INVALID_REVISION)
+		{
+			LockedBy = MoveTemp(InState.LockedBy);
+			LockedWhere = MoveTemp(InState.LockedWhere);
+			RepSpec = MoveTemp(InState.RepSpec);
+			DepotRevisionChangeset = InState.DepotRevisionChangeset;
+			LocalRevisionChangeset = InState.LocalRevisionChangeset;
+		}
+		// Don't override "fileinfo" information in case of an optimized/lightweight "whole folder status" triggered by a global Submit Content or Refresh
+		// and regenerate the LockedByOther state based on LockedBy
+		else if (!IsCheckedOut() && !LockedBy.IsEmpty())
+		{
+			WorkspaceState = EWorkspaceState::LockedByOther;
+		}
 		MovedFrom = MoveTemp(InState.MovedFrom);
 		TimeStamp = InState.TimeStamp;
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -35,8 +35,8 @@ class FPlasticSourceControlState : public ISourceControlState, public TSharedFro
 {
 public:
 
-	FPlasticSourceControlState(const FString& InLocalFilename)
-		: LocalFilename(InLocalFilename)
+	FPlasticSourceControlState(FString&& InLocalFilename)
+		: LocalFilename(MoveTemp(InLocalFilename))
 		, WorkspaceState(EWorkspaceState::Unknown)
 		, DepotRevisionChangeset(-1)
 		, LocalRevisionChangeset(-1)

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -863,11 +863,12 @@ static bool RunStatus(const FString& InDir, const TArray<FString>& InFiles, cons
 	Parameters.Add(TEXT("--noheaders"));
 	Parameters.Add(TEXT("--all"));
 	Parameters.Add(TEXT("--ignored"));
-	// "cm status" only operate on one path (file or folder) at a time, so use one folder path for multiple files in a directory
+	// "cm status" only operate on one path (file or directory) at a time, so use one common path for multiple files in a directory
 	TArray<FString> OnePath;
 	// Only one file: optim very useful for the .uproject file at the root to avoid parsing the whole repository
-	// (does not work if file does not exist anymore)
-	if ((1 == InFiles.Num()) && (FPaths::FileExists(InFiles[0])))
+	// (but doesn't work if the file is deleted)
+	const bool bSingleFile = (InFiles.Num() == 1) && (FPaths::FileExists(InFiles[0]));
+	if (bSingleFile)
 	{
 		OnePath.Add(InFiles[0]);
 	}
@@ -887,7 +888,8 @@ static bool RunStatus(const FString& InDir, const TArray<FString>& InFiles, cons
 			FPaths::NormalizeFilename(Result);
 		}
 
-		if (1 == InFiles.Num() && (InFiles[0] == InDir))
+		const bool bWholeDirectory = (InFiles.Num() == 1) && (InFiles[0] == InDir);
+		if (bWholeDirectory)
 		{
 			// 1) Special case for "status" of a directory: requires a specific parse logic.
 			//   (this is triggered by the "Submit to Source Control" top menu button)
@@ -1296,7 +1298,7 @@ bool RunUpdateStatus(const TArray<FString>& InFiles, const bool bInUpdateHistory
 	// 2) then we can batch Plastic status operation by subdirectory
 	for (auto& Group : GroupOfFiles)
 	{
-		const bool bWholeDirectory = (1 == Group.Value.Files.Num() && (Group.Value.CommonDir == Group.Value.Files[0]));	
+		const bool bWholeDirectory = ((Group.Value.Files.Num() == 1) && (Group.Value.CommonDir == Group.Value.Files[0]));	
 
 		// Run a "status" command on the directory to get workspace file states.
 		// (ie. Changed, CheckedOut, Copied, Replaced, Added, Private, Ignored, Deleted, LocallyDeleted, Moved, LocallyMoved)

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -236,7 +236,7 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 	while (FPlatformProcess::IsProcRunning(ShellProcessHandle))
 	{
 		FString Output = FPlatformProcess::ReadPipe(ShellOutputPipeRead);
-		if (0 < Output.Len())
+		if (!Output.IsEmpty())
 		{
 			LastActivity = FPlatformTime::Seconds(); // freshen the timestamp while cm is still actively outputting information
 			OutResults.Append(MoveTemp(Output));
@@ -249,7 +249,7 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 				{
 					const FString Result = OutResults.Mid(IndexCommandResult + 14, IndexEndResult - IndexCommandResult - 14);
 					const int32 ResultCode = FCString::Atoi(*Result);
-					bResult = (0 == ResultCode);
+					bResult = (ResultCode == 0);
 					// remove the CommandResult line from the OutResults
 					OutResults.RemoveAt(IndexCommandResult, OutResults.Len() - IndexCommandResult);
 					break;
@@ -851,7 +851,7 @@ public:
  */
 static bool RunStatus(const FString& InDir, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, TArray<FString>& OutErrorMessages, TArray<FPlasticSourceControlState>& OutStates, int32& OutChangeset, FString& OutBranchName)
 {
-	ensure(0 < InFiles.Num());
+	check(InFiles.Num() > 0);
 
 	TArray<FString> Parameters;
 
@@ -979,7 +979,7 @@ static void ParseFileinfoResults(const TArray<FString>& InResults, TArray<FPlast
 		FileState.LockedWhere = MoveTemp(FileinfoParser.LockedWhere);
 
 		// If a file is locked but not checked-out locally (or moved/renamed) this means it is locked by someone else or elsewhere
-		if ((FileState.WorkspaceState != EWorkspaceState::CheckedOut) && (FileState.WorkspaceState != EWorkspaceState::Moved) && (0 < FileState.LockedBy.Len())) 
+		if ((FileState.WorkspaceState != EWorkspaceState::CheckedOut) && (FileState.WorkspaceState != EWorkspaceState::Moved) && !FileState.LockedBy.IsEmpty()) 
 		{
 			UE_LOG(LogSourceControl, Verbose, TEXT("LockedByOther(%s) by '%s!=%s' (or %s!=%s)"), *File, *FileState.LockedBy, *Provider.GetUserName(), *FileState.LockedWhere, *Provider.GetWorkspaceName());
 			FileState.WorkspaceState = EWorkspaceState::LockedByOther;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1016,7 +1016,7 @@ static bool RunFileinfo(const bool bInWholeDirectory, const bool bInUpdateHistor
 	for (FPlasticSourceControlState& State : InOutStates)
 	{
 		// 1) Issue a "fileinfo" command for controled files (to know if they are up to date and can be checked-out or checked-in)
-		// but only if controlled unchanged, or locally changed,
+		// but only if controlled unchanged, or locally changed / locally deleted,
 		// optimizing for files that are CheckedOut/Added/Deleted/Moved/Copied/Replaced/NotControled/Ignored/Private/Unknown
 		// (since there is no point to check if they are up to date in these cases; they are already checkedout or not controlld).
 		// This greatly reduce the time needed to do some operations like "Add" or "Move/Rename/Copy" when there is some latency with the server (eg cloud).
@@ -1028,8 +1028,9 @@ static bool RunFileinfo(const bool bInWholeDirectory, const bool bInUpdateHistor
 		// 3) bInUpdateHistory: When the plugin needs to update the history, it needs to know if it's on a XLink,
 		// so the fileinfo command is required here to get the RepSpec
 		if (bInUpdateHistory
-			||	(	(State.WorkspaceState == EWorkspaceState::Controlled) && !bInWholeDirectory)
-				||	(State.WorkspaceState == EWorkspaceState::Changed)
+			|| ((State.WorkspaceState == EWorkspaceState::Controlled) && !bInWholeDirectory)
+			||	(State.WorkspaceState == EWorkspaceState::Changed)
+			||	(State.WorkspaceState == EWorkspaceState::LocallyDeleted)
 			)
 		{
 			SelectedFiles.Add(State.LocalFilename);


### PR DESCRIPTION
Fix Locked & Not-at-head icons disappearing when triggering a "Submit content" or "Refresh" operation

Don't override "fileinfo" information in case of an optimized/lightweight "whole folder status" triggered by a global Submit Content or Refresh

It is important because it let the user thinks that he can submit certain files, while he is missing the last version, or an asset is locked, so the submit will in fact fail.