### PR TITLE
Detect files changed on another branch

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -474,39 +474,33 @@ bool FPlasticUpdateStatusWorker::Execute(FPlasticSourceControlCommand& InCommand
 			UE_LOG(LogSourceControl, Error, TEXT("FPlasticUpdateStatusWorker(ErrorMessages.Num()=%d) => checkconnection"), InCommand.ErrorMessages.Num());
 			// In case of error, execute a 'checkconnection' command to check the connectivity of the server.
 			InCommand.bConnectionDropped = !PlasticSourceControlUtils::RunCommand(TEXT("checkconnection"), TArray<FString>(), TArray<FString>(), InCommand.Concurrency, InCommand.InfoMessages, InCommand.ErrorMessages);
+			return false;
 		}
-		else
-		{
-			if (Operation->ShouldUpdateHistory())
-			{
-				for (int32 IdxFile = 0; IdxFile < States.Num(); IdxFile++)
-				{
-					FString& File = InCommand.Files[IdxFile];
-					FPlasticSourceControlState& State = States[IdxFile];
 
-					// Cannot fetch the history of file not already submitted to source control
-					if (State.IsSourceControlled() && !State.IsAdded())
+		if (Operation->ShouldUpdateHistory())
+		{
+			// Get the history of the files (on all branches)
+			InCommand.bCommandSuccessful &= PlasticSourceControlUtils::RunGetHistory(States, InCommand.ErrorMessages);
+
+			// Special case for conflicts
+			for (FPlasticSourceControlState& State : States)
+			{
+				if (State.IsConflicted())
+				{
+					// In case of a merge conflict, we need to put the tip of the "remote branch" on top of the history
+					UE_LOG(LogSourceControl, Log, TEXT("%s: PendingMergeSourceChangeset %d"), *State.LocalFilename, State.PendingMergeSourceChangeset);
+					for (int32 IdxRevision = 0; IdxRevision < State.History.Num(); IdxRevision++)
 					{
-						// Get the history of the file (on all branches)
-						InCommand.bCommandSuccessful &= PlasticSourceControlUtils::RunGetHistory(File, InCommand.ErrorMessages, State);
-						if (State.IsConflicted())
+						const auto& Revision = State.History[IdxRevision];
+						if (Revision->ChangesetNumber == State.PendingMergeSourceChangeset)
 						{
-							// In case of a merge conflict, we need to put the tip of the "remote branch" on top of the history
-							UE_LOG(LogSourceControl, Log, TEXT("%s: PendingMergeSourceChangeset %d"), *State.LocalFilename, State.PendingMergeSourceChangeset);
-							for (int32 IdxRevision = 0; IdxRevision < State.History.Num(); IdxRevision++)
+							// If the Source Changeset is not already at the top of the History, duplicate it there.
+							if (IdxRevision > 0)
 							{
-								const auto& Revision = State.History[IdxRevision];
-								if (Revision->ChangesetNumber == State.PendingMergeSourceChangeset)
-								{
-									// If the Source Changeset is not already at the top of the History, duplicate it there.
-									if (IdxRevision > 0)
-									{
-										const auto RevisionCopy = Revision;
-										State.History.Insert(RevisionCopy, 0);
-									}
-									break;
-								}
+								const auto RevisionCopy = Revision;
+								State.History.Insert(RevisionCopy, 0);
 							}
+							break;
 						}
 					}
 				}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.cpp
@@ -106,8 +106,8 @@ const FString& FPlasticSourceControlRevision::GetUserName() const
 
 const FString& FPlasticSourceControlRevision::GetClientSpec() const
 {
-	static FString EmptyString(TEXT("")); // NOTE Workspace/Clientspec of the submitter (Perforce only)
-	return EmptyString;
+	// Note: show Branch instead of the Workspace of the submitter since it's Perforce only
+	return Branch;
 }
 
 const FString& FPlasticSourceControlRevision::GetAction() const

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.h
@@ -64,6 +64,9 @@ public:
 	/** The user that made the change */
 	FString UserName;
 
+	/** Branch where the change was made */
+	FString Branch;
+
 	/** The action (add, edit, branch etc.) performed at this revision */
 	FString Action;
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlSettings.cpp
@@ -47,6 +47,18 @@ void FPlasticSourceControlSettings::SetUpdateStatusAtStartup(const bool bInUpdat
 	bUpdateStatusAtStartup = bInUpdateStatusAtStartup;
 }
 
+bool FPlasticSourceControlSettings::GetUpdateStatusOtherBranches() const
+{
+	FScopeLock ScopeLock(&CriticalSection);
+	return bUpdateStatusOtherBranches;
+}
+
+void FPlasticSourceControlSettings::SetUpdateStatusOtherBranches(const bool bInUpdateStatusOtherBranches)
+{
+	FScopeLock ScopeLock(&CriticalSection);
+	bUpdateStatusOtherBranches = bInUpdateStatusOtherBranches;
+}
+
 bool FPlasticSourceControlSettings::GetEnableVerboseLogs() const
 {
 	FScopeLock ScopeLock(&CriticalSection);
@@ -66,6 +78,7 @@ void FPlasticSourceControlSettings::LoadSettings()
 	const FString& IniFile = SourceControlHelpers::GetSettingsIni();
 	GConfig->GetString(*PlasticSettingsConstants::SettingsSection, TEXT("BinaryPath"), BinaryPath, IniFile);
 	GConfig->GetBool(*PlasticSettingsConstants::SettingsSection, TEXT("UpdateStatusAtStartup"), bUpdateStatusAtStartup, IniFile);
+	GConfig->GetBool(*PlasticSettingsConstants::SettingsSection, TEXT("UpdateStatusOtherBranches"), bUpdateStatusOtherBranches, IniFile);
 	GConfig->GetBool(*PlasticSettingsConstants::SettingsSection, TEXT("EnableVerboseLogs"), bEnableVerboseLogs, IniFile);
 }
 
@@ -75,5 +88,6 @@ void FPlasticSourceControlSettings::SaveSettings() const
 	const FString& IniFile = SourceControlHelpers::GetSettingsIni();
 	GConfig->SetString(*PlasticSettingsConstants::SettingsSection, TEXT("BinaryPath"), *BinaryPath, IniFile);
 	GConfig->SetBool(*PlasticSettingsConstants::SettingsSection, TEXT("UpdateStatusAtStartup"), bUpdateStatusAtStartup, IniFile);
+	GConfig->SetBool(*PlasticSettingsConstants::SettingsSection, TEXT("UpdateStatusOtherBranches"), bUpdateStatusOtherBranches, IniFile);
 	GConfig->SetBool(*PlasticSettingsConstants::SettingsSection, TEXT("EnableVerboseLogs"), bEnableVerboseLogs, IniFile);
 }

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlSettings.h
@@ -15,6 +15,10 @@ public:
 	bool GetUpdateStatusAtStartup() const;
 	void SetUpdateStatusAtStartup(const bool bInUpdateStatusAtStartup);
 
+	/** Enable Update status to call "history" to detect recent changesets on other branches (can be slow). */
+	bool GetUpdateStatusOtherBranches() const;
+	void SetUpdateStatusOtherBranches(const bool bInUpdateStatusOtherBranches);
+
 	/** Enable LogSourceControl Verbose logs */
 	bool GetEnableVerboseLogs() const;
 	void SetEnableVerboseLogs(const bool bInEnableVerboseLogs);
@@ -30,14 +34,17 @@ private:
 	mutable FCriticalSection CriticalSection;
 
 	/** Plastic binary path */
-	FString BinaryPath;
+	FString BinaryPath = TEXT("cm");
 
 	/** Run an asynchronous "Update Status" at Editor Startup (default is no).
 	 * This does not work well with very big projects where this operation could take dozens of seconds
 	 * preventing the project to have any source control support during this time.
 	*/
-	bool bUpdateStatusAtStartup;
-	
+	bool bUpdateStatusAtStartup = false;
+
+	/** Enable Update status to call "history" to detect recent changesets on other branches (can be slow). */
+	bool bUpdateStatusOtherBranches = true;
+
 	/** Override LogSourceControl verbosity level to Verbose, and back, if not already VeryVerbose */
-	bool bEnableVerboseLogs;
+	bool bEnableVerboseLogs = false;
 };

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -243,7 +243,7 @@ FText FPlasticSourceControlState::GetDisplayName() const
 	case EWorkspaceState::Controlled:
 		return LOCTEXT("Controlled", "Controlled");
 	case EWorkspaceState::CheckedOut:
-		return LOCTEXT("CheckedOut", "CheckedOut");
+		return LOCTEXT("CheckedOut", "Checked-out");
 	case EWorkspaceState::Added:
 		return LOCTEXT("Added", "Added");
 	case EWorkspaceState::Moved:
@@ -259,7 +259,7 @@ FText FPlasticSourceControlState::GetDisplayName() const
 	case EWorkspaceState::Changed:
 		return LOCTEXT("Changed", "Changed");
 	case EWorkspaceState::Conflicted:
-		return LOCTEXT("ContentsConflict", "Contents Conflict");
+		return LOCTEXT("ContentsConflict", "Conflicted");
 	case EWorkspaceState::LockedByOther:
 		return FText::Format(LOCTEXT("CheckedOutOther", "Checked out by: {0} in {1}"), FText::FromString(LockedBy), FText::FromString(LockedWhere));
 	case EWorkspaceState::Private:
@@ -273,7 +273,7 @@ FText FPlasticSourceControlState::GetDisplayTooltip() const
 {
 	if (!IsCurrent())
 	{
-		return LOCTEXT("NotCurrent_Tooltip", "The file(s) are not at the head revision");
+		return LOCTEXT("NotCurrent_Tooltip", "Not at the head revision");
 	}
 	else if (WorkspaceState != EWorkspaceState::LockedByOther)
 	{
@@ -288,33 +288,33 @@ FText FPlasticSourceControlState::GetDisplayTooltip() const
 	switch (WorkspaceState)
 	{
 	case EWorkspaceState::Unknown:
-		return LOCTEXT("Unknown_Tooltip", "Unknown source control state");
+		return LOCTEXT("Unknown_Tooltip", "The file status is unknown");
 	case EWorkspaceState::Ignored:
-		return LOCTEXT("Ignored_Tooltip", "Item is being ignored.");
+		return LOCTEXT("Ignored_Tooltip", "The file is ignored");
 	case EWorkspaceState::Controlled:
-		return LOCTEXT("Pristine_Tooltip", "There are no modifications");
+		return LOCTEXT("Pristine_Tooltip", "The file has no modification");
 	case EWorkspaceState::CheckedOut:
-		return LOCTEXT("CheckedOut_Tooltip", "Item is checked out");
+		return LOCTEXT("CheckedOut_Tooltip", "The file is checked out");
 	case EWorkspaceState::Added:
-		return LOCTEXT("Added_Tooltip", "Item has been added");
+		return LOCTEXT("Added_Tooltip", "The file has been added");
 	case EWorkspaceState::Moved:
-		return LOCTEXT("Moved_Tooltip", "Item has been moved or renamed");
+		return LOCTEXT("Moved_Tooltip", "The file has been moved or renamed");
 	case EWorkspaceState::Copied:
-		return LOCTEXT("Copied_Tooltip", "Item has been copied");
+		return LOCTEXT("Copied_Tooltip", "The file has been copied");
 	case EWorkspaceState::Replaced:
-		return LOCTEXT("Replaced_Tooltip", "Item has been replaced / merged");
+		return LOCTEXT("Replaced_Tooltip", "The file has been replaced / merged");
 	case EWorkspaceState::Deleted:
-		return LOCTEXT("Deleted_Tooltip", "Item is scheduled for deletion");
+		return LOCTEXT("Deleted_Tooltip", "The file has been deleted");
 	case EWorkspaceState::LocallyDeleted:
-		return LOCTEXT("LocallyDeleted_Tooltip", "Item is missing");
+		return LOCTEXT("LocallyDeleted_Tooltip", "The file is missing");
 	case EWorkspaceState::Changed:
-		return LOCTEXT("Modified_Tooltip", "Item has been modified");
+		return LOCTEXT("Modified_Tooltip", "The file has been modified");
 	case EWorkspaceState::Conflicted:
-		return LOCTEXT("ContentsConflict_Tooltip", "The contents of the item conflict with updates received from the repository.");
+		return LOCTEXT("ContentsConflict_Tooltip", "The content of the file conflict with updates received from the repository");
 	case EWorkspaceState::LockedByOther:
-		return FText::Format(LOCTEXT("CheckedOutOther_Tooltip", "Checked out by: {0} in {1}"), FText::FromString(LockedBy), FText::FromString(LockedWhere));
+		return FText::Format(LOCTEXT("CheckedOutOther_Tooltip", "Checked out by {0} in {1}"), FText::FromString(LockedBy), FText::FromString(LockedWhere));
 	case EWorkspaceState::Private:
-		return LOCTEXT("NotControlled_Tooltip", "Item is not under version control.");
+		return LOCTEXT("NotControlled_Tooltip", "The file is not under version control");
 	}
 
 	return FText();

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -82,6 +82,7 @@ public:
 			LocalRevisionChangeset = InState.LocalRevisionChangeset;
 
 			HeadBranch = MoveTemp(InState.HeadBranch);
+			HeadAction = MoveTemp(InState.HeadAction);
 			HeadChangeList = MoveTemp(InState.HeadChangeList);
 			HeadUserName = MoveTemp(InState.HeadUserName);
 			HeadModTime = MoveTemp(InState.HeadModTime);
@@ -193,12 +194,15 @@ public:
 	/** The branch with the head change list */
 	FString HeadBranch;
 
+	/** The type of action of the last modification */
+	FString HeadAction;
+
 	/** The user of the last modification */
 	FString HeadUserName;
 
 	/** The last file modification time */
 	int64 HeadModTime;
 
-	/** The change list the last modification */
+	/** The change list of the last modification */
 	int32 HeadChangeList;
 };

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -80,6 +80,11 @@ public:
 			RepSpec = MoveTemp(InState.RepSpec);
 			DepotRevisionChangeset = InState.DepotRevisionChangeset;
 			LocalRevisionChangeset = InState.LocalRevisionChangeset;
+
+			HeadBranch = MoveTemp(InState.HeadBranch);
+			HeadChangeList = MoveTemp(InState.HeadChangeList);
+			HeadUserName = MoveTemp(InState.HeadUserName);
+			HeadModTime = MoveTemp(InState.HeadModTime);
 		}
 		// Don't override "fileinfo" information in case of an optimized/lightweight "whole folder status" triggered by a global Submit Content or Refresh
 		// and regenerate the LockedByOther state based on LockedBy
@@ -125,9 +130,9 @@ public:
 	virtual bool IsCheckedOutOther(FString* Who = nullptr) const override;
 	virtual bool IsCheckedOutInOtherBranch(const FString& CurrentBranch = FString()) const override;
 	virtual bool IsModifiedInOtherBranch(const FString& CurrentBranch = FString()) const override;
-	virtual bool IsCheckedOutOrModifiedInOtherBranch(const FString& CurrentBranch = FString()) const override;
-	virtual TArray<FString> GetCheckedOutBranches() const override;
-	virtual FString GetOtherUserBranchCheckedOuts() const override;
+	virtual bool IsCheckedOutOrModifiedInOtherBranch(const FString& CurrentBranch = FString()) const override { return IsCheckedOutInOtherBranch(CurrentBranch) || IsModifiedInOtherBranch(CurrentBranch); }
+	virtual TArray<FString> GetCheckedOutBranches() const override { return TArray<FString>(); }
+	virtual FString GetOtherUserBranchCheckedOuts() const override { return FString(); }
 	virtual bool GetOtherBranchHeadModification(FString& HeadBranchOut, FString& ActionOut, int32& HeadChangeListOut) const override;
 	virtual bool IsCurrent() const override;
 	virtual bool IsSourceControlled() const override;
@@ -182,9 +187,18 @@ public:
 	/** Original name in case of a Moved/Renamed file */
 	FString MovedFrom;
 
-	/** Whether the file is a binary file or not */
-//	bool bBinary;
-
 	/** The timestamp of the last update */
 	FDateTime TimeStamp;
+
+	/** The branch with the head change list */
+	FString HeadBranch;
+
+	/** The user of the last modification */
+	FString HeadUserName;
+
+	/** The last file modification time */
+	int64 HeadModTime;
+
+	/** The change list the last modification */
+	int32 HeadChangeList;
 };

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1425,7 +1425,10 @@ static bool ParseHistoryResults(const FXmlFile& InXmlResult, FPlasticSourceContr
 	InOutState.History.Reserve(RevisionNodes.Num());
 
 	// parse history in reverse: needed to get most recent at the top (implied by the UI)
-	for (int32 Index = RevisionNodes.Num() - 1; Index >= 0; Index--)
+	// Note: limit to last 100 changes, like Perforce
+	static const int32 MaxRevisions = 100;
+	const int32 MinIndex = FMath::Max(0, RevisionNodes.Num() - MaxRevisions);
+	for (int32 Index = RevisionNodes.Num() - 1; Index >= MinIndex; Index--)
 	{
 		if (const FXmlNode* RevisionNode = RevisionNodes[Index])
 		{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1392,6 +1392,7 @@ static bool ParseHistoryResults(const FXmlFile& InXmlResult, TArray<FPlasticSour
 	static const FString ItemName(TEXT("ItemName"));
 	static const FString Revisions(TEXT("Revisions"));
 	static const FString Revision(TEXT("Revision"));
+	static const FString Branch(TEXT("Branch"));
 	static const FString ChangesetNumber(TEXT("ChangesetNumber"));
 	static const FString Comment(TEXT("Comment"));
 	static const FString CreationDate(TEXT("CreationDate"));
@@ -1491,6 +1492,10 @@ static bool ParseHistoryResults(const FXmlFile& InXmlResult, TArray<FPlasticSour
 						DateIso = DateNode->GetContent().LeftChop(10) + DateNode->GetContent().RightChop(27);
 					}
 					FDateTime::ParseIso8601(*DateIso, SourceControlRevision->Date);
+				}
+				if (const FXmlNode* BranchNode = RevisionNode->FindChildNode(Branch))
+				{
+					SourceControlRevision->Branch = BranchNode->GetContent();
 				}
 
 				InOutState.History.Add(SourceControlRevision);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1551,6 +1551,7 @@ static bool ParseHistoryResults(const bool bInUpdateHistory, const FXmlFile& InX
 // Run a Plastic "history" command and parse it's XML result.
 bool RunGetHistory(const bool bInUpdateHistory, TArray<FPlasticSourceControlState>& InOutStates, TArray<FString>& OutErrorMessages)
 {
+	bool bResult = true;
 	FString Results;
 	FString Errors;
 	TArray<FString> Parameters;
@@ -1571,16 +1572,18 @@ bool RunGetHistory(const bool bInUpdateHistory, TArray<FPlasticSourceControlStat
 			Files.Add(State.LocalFilename);
 		}
 	}
-
-	bool bResult = RunCommandInternal(TEXT("history"), Parameters, Files, EConcurrency::Synchronous, Results, Errors);
-	OutErrorMessages.Add(MoveTemp(Errors));
-	if (bResult)
+	if (Files.Num() > 0)
 	{
-		FXmlFile XmlFile;
-		bResult = XmlFile.LoadFile(Results, EConstructMethod::ConstructFromBuffer);
+		bResult = RunCommandInternal(TEXT("history"), Parameters, Files, EConcurrency::Synchronous, Results, Errors);
+		OutErrorMessages.Add(MoveTemp(Errors));
 		if (bResult)
 		{
-			bResult = ParseHistoryResults(bInUpdateHistory, XmlFile, InOutStates);
+			FXmlFile XmlFile;
+			bResult = XmlFile.LoadFile(Results, EConstructMethod::ConstructFromBuffer);
+			if (bResult)
+			{
+				bResult = ParseHistoryResults(bInUpdateHistory, XmlFile, InOutStates);
+			}
 		}
 	}
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1442,8 +1442,7 @@ static bool ParseHistoryResults(const FXmlFile& InXmlResult, FPlasticSourceContr
 			else
 				SourceControlRevision->Action = TEXT("edit");
 
-			const FXmlNode* ChangesetNumberNode = RevisionNode->FindChildNode(ChangesetNumber);
-			if (ChangesetNumberNode != nullptr)
+			if (const FXmlNode* ChangesetNumberNode = RevisionNode->FindChildNode(ChangesetNumber))
 			{
 				const FString& Changeset = ChangesetNumberNode->GetContent();
 				SourceControlRevision->ChangesetNumber = FCString::Atoi(*Changeset); // Value now used in the Revision column and in the Asset Menu History
@@ -1460,18 +1459,15 @@ static bool ParseHistoryResults(const FXmlFile& InXmlResult, FPlasticSourceContr
 					SourceControlRevision->Revision = FString::Printf(TEXT("cs:%s"), *Changeset);
 				}
 			}
-			const FXmlNode* CommentNode = RevisionNode->FindChildNode(Comment);
-			if (CommentNode != nullptr)
+			if (const FXmlNode* CommentNode = RevisionNode->FindChildNode(Comment))
 			{
 				SourceControlRevision->Description = CommentNode->GetContent();
 			}
-			const FXmlNode* OwnerNode = RevisionNode->FindChildNode(Owner);
-			if (OwnerNode != nullptr)
+			if (const FXmlNode* OwnerNode = RevisionNode->FindChildNode(Owner))
 			{
 				SourceControlRevision->UserName = OwnerNode->GetContent();
 			}
-			const FXmlNode* DateNode = RevisionNode->FindChildNode(CreationDate);
-			if (DateNode != nullptr)
+			if (const FXmlNode* DateNode = RevisionNode->FindChildNode(CreationDate))
 			{
 				FString DateIso = DateNode->GetContent();
 				const int len = DateIso.Len();

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -103,7 +103,7 @@ bool RunCommandInternal(const FString& InCommand, const TArray<FString>& InParam
  * Run a Plastic "status" command and parse it.
  *
  * @param	InFiles				The files to be operated on
- * @param	bInUpdateHistory	If getting the history of a file, force execute the fileinfo command required to do get RepSpec of xlinks (history view or visual diff)
+ * @param	bInUpdateHistory	If getting the history of files, force execute the fileinfo command required to do get RepSpec of xlinks (history view or visual diff)
  * @param	InConcurrency		Is the command running in the background, or blocking the main thread
  * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
  * @param	OutStates			States of the files
@@ -126,11 +126,10 @@ bool RunDumpToFile(const FString& InPathToPlasticBinary, const FString& InRevSpe
 /**
  * Run a Plastic "history" and "log" commands and parse it.
  *
- * @param	InFile				The file to be operated on
+ * @param	InOutStates			The file states to update with the history
  * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
- * @param	InOutState			The status to update with the history of the file
  */
-bool RunGetHistory(const FString& InFile, TArray<FString>& OutErrorMessages, FPlasticSourceControlState& InOutState);
+bool RunGetHistory(TArray<FPlasticSourceControlState>& InOutStates, TArray<FString>& OutErrorMessages);
 
 /**
  * Helper function for various commands to update cached states.

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -126,10 +126,11 @@ bool RunDumpToFile(const FString& InPathToPlasticBinary, const FString& InRevSpe
 /**
  * Run a Plastic "history" and "log" commands and parse it.
  *
+ * @param	bInUpdateHistory	If getting the history of files, versus only checking the heads of branches to detect newer commits
  * @param	InOutStates			The file states to update with the history
  * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
  */
-bool RunGetHistory(TArray<FPlasticSourceControlState>& InOutStates, TArray<FString>& OutErrorMessages);
+bool RunGetHistory(const bool bInUpdateHistory, TArray<FPlasticSourceControlState>& InOutStates, TArray<FString>& OutErrorMessages);
 
 /**
  * Helper function for various commands to update cached states.

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
@@ -54,6 +54,9 @@ private:
 	void OnCheckedUpdateStatusAtStartup(ECheckBoxState NewCheckedState);
 	ECheckBoxState IsUpdateStatusAtStartupChecked() const;
 
+	void OnCheckedUpdateStatusOtherBranches(ECheckBoxState NewCheckedState);
+	ECheckBoxState IsUpdateStatusOtherBranchesChecked() const;
+
 	void OnCheckedEnableVerboseLogs(ECheckBoxState NewCheckedState);
 	ECheckBoxState IsEnableVerboseLogsChecked() const;
 


### PR DESCRIPTION
Get the latest revision of files on all branches
- Display a specific "not at head" icon, with a text like "Change on /main/xxx by yyy"
- Warn if trying to checkout a file that has a newer revision in another branch