### PR TITLE
Don't call cm "add" with "-R" except for the initial workspace init

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -245,18 +245,24 @@ bool FPlasticMarkForAddWorker::Execute(FPlasticSourceControlCommand& InCommand)
 	check(InCommand.Operation->GetName() == GetName());
 
 	TArray<FString> Parameters;
-	Parameters.Add(TEXT("--parents"));
-	// Note: this is a workaround to trigger the Plastic's "SkipIgnored" internal flag meaning "don't add file that are ignored":
+	Parameters.Add(TEXT("--parents")); // NOTE: deprecated in 8.0.16.3100 when it became the default https://www.plasticscm.com/download/releasenotes/8.0.16.3100
+	// Note: using "?" is a workaround to trigger the Plastic's "SkipIgnored" internal flag meaning "don't add file that are ignored":
 	//			options.SkipIgnored = cla.GetWildCardArguments().Count > 0;
 	//		 It's behavior is similar as Subversion:
 	//  		if you explicitely add one file that is ignored, "cm" will happily accept it and add it,
 	//			if you try to add a set of files with a pattern, "cm" will skip the files that are ignored and only add the other ones
-	// TODO: provide an updated version of "cm" with a proper --skipignored flag (or with a better naming).
-	Parameters.Add(TEXT("?"));
+	// TODO: provide an updated version of "cm" with a new flag like --applyignorerules
+	if (AreAllFiles(InCommand.Files))
+	{
+		Parameters.Add(TEXT("?"));	// needed only when used with a list of files
+	}
+	else
+	{
+		Parameters.Add(TEXT("-R"));	// needed only at the time of workspace creation, to add directories recursively
+	}
 	// Detect special case for a partial checkout (CS:-1 in Gluon mode)!
 	if (-1 != InCommand.ChangesetNumber)
 	{
-		Parameters.Add(TEXT("-R")); // needed at the time of workspace creation, but not working in a partial workspace
 		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("add"), Parameters, InCommand.Files, InCommand.Concurrency, InCommand.InfoMessages, InCommand.ErrorMessages);
 	}
 	else


### PR DESCRIPTION
where adding whole directories instead of just files

This fixes a bug found on a huge repository where adding one single file was triggering adding the content of a plugin

Note: --parents has been deprecated in 8.0.16.3100 when it became the default
https://www.plasticscm.com/download/releasenotes/8.0.16.3100