### PR TITLE
Fix CheckIn and Add commands behaving wrongly if called with an empty list of files

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -181,51 +181,59 @@ bool FPlasticCheckInWorker::Execute(FPlasticSourceControlCommand& InCommand)
 	check(InCommand.Operation->GetName() == GetName());
 	TSharedRef<FCheckIn, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FCheckIn>(InCommand.Operation);
 
-	// make a temp file to place our commit message in
-	FScopedTempFile CommitMsgFile(Operation->GetDescription());
-	if (!CommitMsgFile.GetFilename().IsEmpty())
+	if (InCommand.Files.Num() > 0)
 	{
-		TArray<FString> Parameters;
-		FString ParamCommitMsgFilename = TEXT("--commentsfile=\"");
-		ParamCommitMsgFilename += FPaths::ConvertRelativePathToFull(CommitMsgFile.GetFilename());
-		ParamCommitMsgFilename += TEXT("\"");
-		Parameters.Add(ParamCommitMsgFilename);
-		// Detect special case for a partial checkout (CS:-1 in Gluon mode)!
-		if (-1 != InCommand.ChangesetNumber)
+		// make a temp file to place our commit message in
+		FScopedTempFile CommitMsgFile(Operation->GetDescription());
+		if (!CommitMsgFile.GetFilename().IsEmpty())
 		{
-			Parameters.Add(TEXT("--all")); // Also files Changed (not CheckedOut) and Moved/Deleted Locally
-		//  NOTE: --update added as #23 but removed as #32 because most assets are locked by the Unreal Editor
-		//	Parameters.Add(TEXT("--update")); // Processes the update-merge automatically if it eventually happens.
-			InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("checkin"), Parameters, InCommand.Files, InCommand.Concurrency, InCommand.InfoMessages, InCommand.ErrorMessages);
-		}
-		else
-		{
-			Parameters.Add(TEXT("--applychanged")); // Also files Changed (not CheckedOut) and Moved/Deleted Locally
-			InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("partial checkin"), Parameters, InCommand.Files, InCommand.Concurrency, InCommand.InfoMessages, InCommand.ErrorMessages);
-		}
-		if (InCommand.bCommandSuccessful)
-		{
-			// Remove any deleted files from status cache
-			FPlasticSourceControlModule& PlasticSourceControl = FModuleManager::GetModuleChecked<FPlasticSourceControlModule>("PlasticSourceControl");
-			FPlasticSourceControlProvider& Provider = PlasticSourceControl.GetProvider();
-
-			TArray<TSharedRef<ISourceControlState, ESPMode::ThreadSafe>> LocalStates;
-			Provider.GetState(InCommand.Files, LocalStates, EStateCacheUsage::Use);
-			for (const auto& State : LocalStates)
+			TArray<FString> Parameters;
+			FString ParamCommitMsgFilename = TEXT("--commentsfile=\"");
+			ParamCommitMsgFilename += FPaths::ConvertRelativePathToFull(CommitMsgFile.GetFilename());
+			ParamCommitMsgFilename += TEXT("\"");
+			Parameters.Add(ParamCommitMsgFilename);
+			// Detect special case for a partial checkout (CS:-1 in Gluon mode)!
+			if (-1 != InCommand.ChangesetNumber)
 			{
-				if (State->IsDeleted())
-				{
-					Provider.RemoveFileFromCache(State->GetFilename());
-				}
+				Parameters.Add(TEXT("--all")); // Also files Changed (not CheckedOut) and Moved/Deleted Locally
+			//  NOTE: --update added as #23 but removed as #32 because most assets are locked by the Unreal Editor
+			//	Parameters.Add(TEXT("--update")); // Processes the update-merge automatically if it eventually happens.
+				InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("checkin"), Parameters, InCommand.Files, InCommand.Concurrency, InCommand.InfoMessages, InCommand.ErrorMessages);
 			}
+			else
+			{
+				Parameters.Add(TEXT("--applychanged")); // Also files Changed (not CheckedOut) and Moved/Deleted Locally
+				InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("partial checkin"), Parameters, InCommand.Files, InCommand.Concurrency, InCommand.InfoMessages, InCommand.ErrorMessages);
+			}
+			if (InCommand.bCommandSuccessful)
+			{
+				// Remove any deleted files from status cache
+				FPlasticSourceControlModule& PlasticSourceControl = FModuleManager::GetModuleChecked<FPlasticSourceControlModule>("PlasticSourceControl");
+				FPlasticSourceControlProvider& Provider = PlasticSourceControl.GetProvider();
 
-			Operation->SetSuccessMessage(ParseCheckInResults(InCommand.InfoMessages));
-			UE_LOG(LogSourceControl, Log, TEXT("CheckIn successful"));
+				TArray<TSharedRef<ISourceControlState, ESPMode::ThreadSafe>> LocalStates;
+				Provider.GetState(InCommand.Files, LocalStates, EStateCacheUsage::Use);
+				for (const auto& State : LocalStates)
+				{
+					if (State->IsDeleted())
+					{
+						Provider.RemoveFileFromCache(State->GetFilename());
+					}
+				}
+
+				Operation->SetSuccessMessage(ParseCheckInResults(InCommand.InfoMessages));
+				UE_LOG(LogSourceControl, Log, TEXT("CheckIn successful"));
+			}
 		}
-	}
 
-	// now update the status of our files
-	PlasticSourceControlUtils::RunUpdateStatus(InCommand.Files, false, InCommand.Concurrency, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
+		// now update the status of our files
+		PlasticSourceControlUtils::RunUpdateStatus(InCommand.Files, false, InCommand.Concurrency, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
+	}
+	else
+	{
+		UE_LOG(LogSourceControl, Error, TEXT("FPlasticCheckInWorker: No file to checkin"));
+		InCommand.ErrorMessages.Add(TEXT("No file to checkin"));
+	}
 
 	return InCommand.bCommandSuccessful;
 }
@@ -244,34 +252,42 @@ bool FPlasticMarkForAddWorker::Execute(FPlasticSourceControlCommand& InCommand)
 {
 	check(InCommand.Operation->GetName() == GetName());
 
-	TArray<FString> Parameters;
-	Parameters.Add(TEXT("--parents")); // NOTE: deprecated in 8.0.16.3100 when it became the default https://www.plasticscm.com/download/releasenotes/8.0.16.3100
-	// Note: using "?" is a workaround to trigger the Plastic's "SkipIgnored" internal flag meaning "don't add file that are ignored":
-	//			options.SkipIgnored = cla.GetWildCardArguments().Count > 0;
-	//		 It's behavior is similar as Subversion:
-	//  		if you explicitely add one file that is ignored, "cm" will happily accept it and add it,
-	//			if you try to add a set of files with a pattern, "cm" will skip the files that are ignored and only add the other ones
-	// TODO: provide an updated version of "cm" with a new flag like --applyignorerules
-	if (AreAllFiles(InCommand.Files))
+	if (InCommand.Files.Num() > 0)
 	{
-		Parameters.Add(TEXT("?"));	// needed only when used with a list of files
-	}
-	else
-	{
-		Parameters.Add(TEXT("-R"));	// needed only at the time of workspace creation, to add directories recursively
-	}
-	// Detect special case for a partial checkout (CS:-1 in Gluon mode)!
-	if (-1 != InCommand.ChangesetNumber)
-	{
-		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("add"), Parameters, InCommand.Files, InCommand.Concurrency, InCommand.InfoMessages, InCommand.ErrorMessages);
-	}
-	else
-	{
-		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("partial add"), Parameters, InCommand.Files, InCommand.Concurrency, InCommand.InfoMessages, InCommand.ErrorMessages);
-	}
+		TArray<FString> Parameters;
+		Parameters.Add(TEXT("--parents")); // NOTE: deprecated in 8.0.16.3100 when it became the default https://www.plasticscm.com/download/releasenotes/8.0.16.3100
+		// Note: using "?" is a workaround to trigger the Plastic's "SkipIgnored" internal flag meaning "don't add file that are ignored":
+		//			options.SkipIgnored = cla.GetWildCardArguments().Count > 0;
+		//		 It's behavior is similar as Subversion:
+		//  		if you explicitely add one file that is ignored, "cm" will happily accept it and add it,
+		//			if you try to add a set of files with a pattern, "cm" will skip the files that are ignored and only add the other ones
+		// TODO: provide an updated version of "cm" with a new flag like --applyignorerules
+		if (AreAllFiles(InCommand.Files))
+		{
+			Parameters.Add(TEXT("?"));	// needed only when used with a list of files
+		}
+		else
+		{
+			Parameters.Add(TEXT("-R"));	// needed only at the time of workspace creation, to add directories recursively
+		}
+		// Detect special case for a partial checkout (CS:-1 in Gluon mode)!
+		if (-1 != InCommand.ChangesetNumber)
+		{
+			InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("add"), Parameters, InCommand.Files, InCommand.Concurrency, InCommand.InfoMessages, InCommand.ErrorMessages);
+		}
+		else
+		{
+			InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("partial add"), Parameters, InCommand.Files, InCommand.Concurrency, InCommand.InfoMessages, InCommand.ErrorMessages);
+		}
 
-	// now update the status of our files
-	PlasticSourceControlUtils::RunUpdateStatus(InCommand.Files, false, InCommand.Concurrency, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
+		// now update the status of our files
+		PlasticSourceControlUtils::RunUpdateStatus(InCommand.Files, false, InCommand.Concurrency, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
+	}
+	else
+	{
+		UE_LOG(LogSourceControl, Error, TEXT("FPlasticCheckInWorker: No file to checkin"));
+		InCommand.ErrorMessages.Add(TEXT("No file to add"));
+	}
 
 	return InCommand.bCommandSuccessful;
 }


### PR DESCRIPTION
In both cases it results in checking everything from the workspace