### PR TITLE
Fix performance issue with the new call to "history" added to each UpdateStatus()

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1555,7 +1555,9 @@ bool RunGetHistory(const bool bInUpdateHistory, TArray<FPlasticSourceControlStat
 	FString Results;
 	FString Errors;
 	TArray<FString> Parameters;
-	Parameters.Add(TEXT("--moveddeleted"));
+	// Detecting move and deletion is costly as it is implemented as two extra queries to the server; do it only when getting the history of the current branch
+	if (bInUpdateHistory)
+		Parameters.Add(TEXT("--moveddeleted"));
 	Parameters.Add(TEXT("--xml"));
 	Parameters.Add(TEXT("--encoding=\"utf-8\""));
 


### PR DESCRIPTION
Detecting move and deletion with --moveddeleted is costly as it is implemented as two extra queries to the server; do it only when getting the history of the current branch