### PR TITLE
Fix connection error detection and reconnection

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -125,6 +125,12 @@ public:
 		return ChangesetNumber;
 	}
 
+	/** Set list of error messages that occurred after last Plastic command */
+	void SetLastErrors(const TArray<FString>& InErrors);
+
+	/** Get list of error messages that occurred after last Plastic command */
+	TArray<FString> GetLastErrors() const;
+
 	/** Helper function used to update state cache */
 	TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> GetStateInternal(const FString& InFilename) const;
 
@@ -147,6 +153,12 @@ private:
 
 	/** Indicates if source control integration is available or not. */
 	bool bServerAvailable;
+
+	/** Critical section for thread safety of error messages that occurred after last Plastic command */
+	mutable FCriticalSection LastErrorsCriticalSection;
+
+	/** List of error messages that occurred after last Plastic command */
+	TArray<FString> LastErrors;
 
 	/** Helper function for Execute() */
 	TSharedPtr<class IPlasticSourceControlWorker, ESPMode::ThreadSafe> CreateWorker(const FName& InOperationName) const;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -473,18 +473,18 @@ void GetUserName(FString& OutUserName)
 	}
 }
 
-bool GetWorkspaceName(FString& OutWorkspaceName)
+bool GetWorkspaceName(const FString& InWorkspaceRoot, FString& OutWorkspaceName, TArray<FString>& OutErrorMessages)
 {
 	TArray<FString> InfoMessages;
-	TArray<FString> ErrorMessages;
+
 	TArray<FString> Parameters;
-	Parameters.Add(TEXT("."));
+	Parameters.Add(InWorkspaceRoot);
 	Parameters.Add(TEXT("--format={0}"));
 	// Get the workspace name
-	const bool bResult = RunCommand(TEXT("getworkspacefrompath"), Parameters, TArray<FString>(), EConcurrency::Synchronous, InfoMessages, ErrorMessages);
+	const bool bResult = RunCommand(TEXT("getworkspacefrompath"), Parameters, TArray<FString>(), EConcurrency::Synchronous, InfoMessages, OutErrorMessages);
 	if (bResult && InfoMessages.Num() > 0)
 	{
-		// NOTE: getworkspacefrompath never returns an error!
+		// NOTE: getworkspacefrompath didn't return an error
 		if (!InfoMessages[0].Equals(TEXT(". is not in a workspace.")))
 		{
 			OutWorkspaceName = MoveTemp(InfoMessages[0]);
@@ -535,10 +535,9 @@ static bool ParseWorkspaceInformation(const TArray<FString>& InInfoMessages, int
 	return bResult;
 }
 
-bool GetWorkspaceInformation(int32& OutChangeset, FString& OutRepositoryName, FString& OutServerUrl, FString& OutBranchName)
+bool GetWorkspaceInformation(int32& OutChangeset, FString& OutRepositoryName, FString& OutServerUrl, FString& OutBranchName, TArray<FString>& OutErrorMessages)
 {
 	TArray<FString> InfoMessages;
-	TArray<FString> ErrorMessages;
 	TArray<FString> Parameters;
 
 	// Command-line format output changed with version 8.0.16.3000, see https://www.plasticscm.com/download/releasenotes/8.0.16.3000
@@ -553,7 +552,7 @@ bool GetWorkspaceInformation(int32& OutChangeset, FString& OutRepositoryName, FS
 	}
 	// NOTE: --wkconfig results in two network calls GetBranchInfoByName & GetLastChangesetOnBranch so it's okay to do it once here but not all the time
 	Parameters.Add(TEXT("--wkconfig")); // Branch name. NOTE: Deprecated in 8.0.16.3000 https://www.plasticscm.com/download/releasenotes/8.0.16.3000
-	bool bResult = RunCommand(TEXT("status"), Parameters, TArray<FString>(), EConcurrency::Synchronous, InfoMessages, ErrorMessages);
+	bool bResult = RunCommand(TEXT("status"), Parameters, TArray<FString>(), EConcurrency::Synchronous, InfoMessages, OutErrorMessages);
 	if (bResult)
 	{
 		bResult = ParseWorkspaceInformation(InfoMessages, OutChangeset, OutRepositoryName, OutServerUrl, OutBranchName);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -72,8 +72,9 @@ void GetUserName(FString& OutUserName);
 /**
  * Get Plastic workspace name
  * @param	OutWorkspaceName	Name of the current workspace
- */
-bool GetWorkspaceName(FString& OutWorkspaceName);
+  * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
+*/
+bool GetWorkspaceName(const FString& InWorkspaceRoot, FString& OutWorkspaceName, TArray<FString>& OutErrorMessages);
 
 /**
  * Get Plastic repository name and server URL, branch name and current changeset number
@@ -81,8 +82,9 @@ bool GetWorkspaceName(FString& OutWorkspaceName);
  * @param	OutRepositoryName	Name of the repository of the current workspace
  * @param	OutServerUrl		URL/Port of the server of the repository
  * @param	OutBranchName		Name of the current checked-out branch
+  * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
  */
-bool GetWorkspaceInformation(int32& OutChangeset, FString& OutRepositoryName, FString& OutServerUrl, FString& OutBranchName);
+bool GetWorkspaceInformation(int32& OutChangeset, FString& OutRepositoryName, FString& OutServerUrl, FString& OutBranchName, TArray<FString>& OutErrorMessages);
 
 /**
  * Run a Plastic command - output is a string TArray.


### PR DESCRIPTION
1. wrong error message if you just unplug the cable/disable the Plastic SCM service, it tells something like "no workspace available)
2. when the server get back online, the Editor didn't ever fully recover, keep showing the "server unavailable" icon 