### PR TITLE
1001608 handle shell exit immediately

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -149,7 +149,7 @@ bool FPlasticConnectWorker::Execute(FPlasticSourceControlCommand& InCommand)
 	}
 	else
 	{
-		const FText ErrorText(LOCTEXT("PlasticScmCliUnavaillable", "Failed to launch Plastic SCM 'cm' command line tool. You need to install it, or configure the correct path to 'cm'."));
+		const FText ErrorText(LOCTEXT("PlasticScmCliUnavaillable", "Failed to launch Plastic SCM 'cm' command line tool. You need to install it and make sure that 'cm' is on the Path and correctly configured."));
 		Operation->SetErrorText(ErrorText);
 		InCommand.ErrorMessages.Add(ErrorText.ToString());
 	}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -117,22 +117,29 @@ void FPlasticSourceControlProvider::CheckPlasticAvailability()
 
 		// Launch the Plastic SCM cli shell on the background to issue all commands during this session
 		bPlasticAvailable = PlasticSourceControlUtils::LaunchBackgroundPlasticShell(PathToPlasticBinary, PathToWorkspaceRoot);
-		if (bPlasticAvailable)
+		if (!bPlasticAvailable)
 		{
-			PlasticSourceControlUtils::GetPlasticScmVersion(PlasticScmVersion);
+			return;
+		}
 
-			// Get user name (from the global Plastic SCM client config)
-			PlasticSourceControlUtils::GetUserName(UserName);
+		PlasticSourceControlUtils::GetPlasticScmVersion(PlasticScmVersion);
+		bPlasticAvailable = PlasticSourceControlUtils::GetPlasticScmVersion(PlasticScmVersion);
+		if (!bPlasticAvailable)
+		{
+			return;
+		}
 
-			// Register Console Commands
-			PlasticSourceControlConsole.Register();
+		// Get user name (from the global Plastic SCM client config)
+		PlasticSourceControlUtils::GetUserName(UserName);
 
-			if (!bWorkspaceFound)
-			{
-				FFormatNamedArguments Args;
-				Args.Add(TEXT("WorkspacePath"), FText::FromString(PathToWorkspaceRoot));
-				FMessageLog("SourceControl").Info(FText::Format(LOCTEXT("NotInAWorkspace", "{WorkspacePath} is not in a workspace."), Args));
-			}
+		// Register Console Commands
+		PlasticSourceControlConsole.Register();
+
+		if (!bWorkspaceFound)
+		{
+			FFormatNamedArguments Args;
+			Args.Add(TEXT("WorkspacePath"), FText::FromString(PathToWorkspaceRoot));
+			FMessageLog("SourceControl").Info(FText::Format(LOCTEXT("NotInAWorkspace", "{WorkspacePath} is not in a workspace."), Args));
 		}
 	}
 }

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -21,7 +21,6 @@
 #include "Misc/Paths.h"
 #include "HAL/PlatformProcess.h"
 #include "Misc/QueuedThreadPool.h"
-#include "Editor.h"
 
 #define LOCTEXT_NAMESPACE "PlasticSourceControl"
 
@@ -67,29 +66,6 @@ void FPlasticSourceControlProvider::Init(bool bForceConnection)
 			{
 				SourceControlLog.Error(FText::FromString(ErrorMessage));
 			}
-		}
-	}
-
-	// only pop-up error once, and only when the Editor has fully started
-	if (GEditor)
-	{
-		if (bPlasticAvailable)
-		{
-			if (PlasticScmVersion < PlasticSourceControlUtils::GetOldestSupportedPlasticScmVersion())
-			{
-				FFormatNamedArguments Args;
-				Args.Add(TEXT("PlasticScmVersion"), FText::FromString(PlasticScmVersion.String));
-				Args.Add(TEXT("OldestSupportedPlasticScmVersion"), FText::FromString(PlasticSourceControlUtils::GetOldestSupportedPlasticScmVersion().String));
-				const FText UnsuportedVersionWarning = FText::Format(LOCTEXT("Plastic_UnsuportedVersion", "Plastic SCM {PlasticScmVersion} is not supported anymore by this plugin.\nPlastic SCM {OldestSupportedPlasticScmVersion} or a more recent version is required.\nPlease upgrade to the latest version."), Args);
-				FMessageLog("SourceControl").Warning(UnsuportedVersionWarning);
-				FMessageDialog::Open(EAppMsgType::Ok, UnsuportedVersionWarning);
-			}
-		}
-		else
-		{
-			const FText CmNotFound(LOCTEXT("Plastic_CmNotAvailable", "Plastic SCM Command Line tool 'cm' not found.\nPlease make sure to install Plastic SCM."));
-			FMessageLog("SourceControl").Error(CmNotFound);
-			FMessageDialog::Open(EAppMsgType::Ok, CmNotFound);
 		}
 	}
 }
@@ -488,6 +464,27 @@ void FPlasticSourceControlProvider::UpdateWorkspaceStatus(const class FPlasticSo
 		WorkspaceName = InCommand.WorkspaceName;
 		RepositoryName = InCommand.RepositoryName;
 		ServerUrl = InCommand.ServerUrl;
+
+		// only pop-up errors when running in full Editor, not in command line scripts
+		if (!IsRunningCommandlet())
+		{
+			if (bPlasticAvailable)
+			{
+				if (PlasticScmVersion < PlasticSourceControlUtils::GetOldestSupportedPlasticScmVersion())
+				{
+					FFormatNamedArguments Args;
+					Args.Add(TEXT("PlasticScmVersion"), FText::FromString(PlasticScmVersion.String));
+					Args.Add(TEXT("OldestSupportedPlasticScmVersion"), FText::FromString(PlasticSourceControlUtils::GetOldestSupportedPlasticScmVersion().String));
+					const FText UnsuportedVersionWarning = FText::Format(LOCTEXT("Plastic_UnsuportedVersion", "Plastic SCM {PlasticScmVersion} is not supported anymore by this plugin.\nPlastic SCM {OldestSupportedPlasticScmVersion} or a more recent version is required.\nPlease upgrade to the latest version."), Args);
+					FMessageLog("SourceControl").Warning(UnsuportedVersionWarning);
+					FMessageDialog::Open(EAppMsgType::Ok, UnsuportedVersionWarning);
+				}
+			}
+			else if (InCommand.ErrorMessages.Num() > 0)
+			{
+				FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(InCommand.ErrorMessages[0]));
+			}
+		}
 
 		if (bWorkspaceFound)
 		{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -447,7 +447,7 @@ bool FindRootDirectory(const FString& InPath, FString& OutWorkspaceRoot)
 }
 
 // This is called once by FPlasticSourceControlProvider::CheckPlasticAvailability()
-void GetPlasticScmVersion(FSoftwareVersion& OutPlasticScmVersion)
+bool GetPlasticScmVersion(FSoftwareVersion& OutPlasticScmVersion)
 {
 	TArray<FString> InfoMessages;
 	TArray<FString> ErrorMessages;
@@ -455,7 +455,9 @@ void GetPlasticScmVersion(FSoftwareVersion& OutPlasticScmVersion)
 	if (bResult && InfoMessages.Num() > 0)
 	{
 		OutPlasticScmVersion = FSoftwareVersion(InfoMessages[0]);
+		return true;
 	}
+	return false;
 }
 
 void GetUserName(FString& OutUserName)

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -67,7 +67,7 @@ bool FindRootDirectory(const FString& InPathToGameDir, FString& OutWorkspaceRoot
  * Get Plastic SCM cli version
  * @param	OutCliVersion		Version of the Plastic SCM Command Line Interface tool
 */
-void GetPlasticScmVersion(FSoftwareVersion& OutPlasticScmVersion);
+bool GetPlasticScmVersion(FSoftwareVersion& OutPlasticScmVersion);
 
 /**
  * Get Plastic SCM current user

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
@@ -76,6 +76,17 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 				.Font(Font)
 			]
 		]
+		// Plastic SCM command line tool not available warning
+		+SVerticalBox::Slot()
+		.FillHeight(1.0f)
+		.Padding(2.0f)
+		[
+			SNew(STextBlock)
+			.Visibility(this, &SPlasticSourceControlSettings::PlasticNotAvailable)
+			.ToolTipText(LOCTEXT("PlasticNotAvailable_Tooltip", "Failed to launch Plastic SCM 'cm' command line tool. You need to install it and make sure that 'cm' is on the Path and correctly configured."))
+			.Text(LOCTEXT("PlasticNotAvailable", "Plastic SCM Command Line tool 'cm' failed to start:"))
+			.Font(Font)
+		]
 		// Path to the Plastic SCM binary
 		+SVerticalBox::Slot()
 		.AutoHeight()
@@ -83,12 +94,12 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 		.VAlign(VAlign_Center)
 		[
 			SNew(SHorizontalBox)
-			.ToolTipText(LOCTEXT("BinaryPathLabel_Tooltip", "Path to the Plastic SCM cli binary"))
+			.ToolTipText(LOCTEXT("BinaryPathLabel_Tooltip", "Path to the Plastic SCM Command Line tool 'cm' binary"))
 			+SHorizontalBox::Slot()
 			.FillWidth(1.0f)
 			[
 				SNew(STextBlock)
-				.Text(LOCTEXT("PathLabel", "Plastic SCM Path"))
+				.Text(LOCTEXT("PathLabel", "Plastic SCM Path to cm"))
 				.Font(Font)
 			]
 			+SHorizontalBox::Slot()
@@ -413,6 +424,12 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 	]
 #endif
 	];
+}
+
+EVisibility SPlasticSourceControlSettings::PlasticNotAvailable() const
+{
+	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+	return Provider.IsPlasticAvailable() ? EVisibility::Collapsed : EVisibility::Visible;
 }
 
 FText SPlasticSourceControlSettings::GetBinaryPathText() const

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
@@ -23,6 +23,8 @@ public:
 	void Construct(const FArguments& InArgs);
 
 private:
+	EVisibility PlasticNotAvailable() const;
+
 	/** Delegate to get cm binary path from settings */
 	FText GetBinaryPathText() const;
 

--- a/Source/PlasticSourceControl/Private/SoftwareVersion.h
+++ b/Source/PlasticSourceControl/Private/SoftwareVersion.h
@@ -14,7 +14,7 @@ struct FSoftwareVersion
 	explicit FSoftwareVersion(const FString& InVersionString);
 	explicit FSoftwareVersion(const int& InMajor, const int& InMinor, const int& InPatch, const int& InChangeset);
 
-	FString String;
+	FString String = TEXT("<unknow-version>");
 
 	int Major = 0;
 	int Minor = 0;

--- a/Source/PlasticSourceControl/Private/SoftwareVersion.h
+++ b/Source/PlasticSourceControl/Private/SoftwareVersion.h
@@ -14,7 +14,7 @@ struct FSoftwareVersion
 	explicit FSoftwareVersion(const FString& InVersionString);
 	explicit FSoftwareVersion(const int& InMajor, const int& InMinor, const int& InPatch, const int& InChangeset);
 
-	FString String = TEXT("<unknow-version>");
+	FString String = TEXT("<unknown-version>");
 
 	int Major = 0;
 	int Minor = 0;


### PR DESCRIPTION
Set bPlasticAvailable to false if unable to read the version.
Fire the popup only at the end of the Connect operation, end just display the error message from it.
Also display an text on the Source Control Login window
![image](https://user-images.githubusercontent.com/101874327/178209496-0b3402da-3417-4edc-a62e-7bd16df8e8c9.png)
![image](https://user-images.githubusercontent.com/101874327/178209810-c4995d0b-113f-42ef-9235-281bf19ce504.png)
![image](https://user-images.githubusercontent.com/101874327/178211082-fcec38dc-f1d7-4c97-b0a2-1afbf85deee1.png)
